### PR TITLE
inc restore

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -199,7 +199,11 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	}
 
 	progress := restoreui.NewProgress(printer, calculateProgressInterval(!gopts.Quiet, gopts.JSON))
-	res := restorer.NewRestorer(repo, sn, opts.Sparse, opts.SkipExisting, opts.ReChunk, opts.QuickChangeCheck, progress)
+	res := restorer.NewRestorer(repo, sn, opts.Sparse, progress,
+		restorer.WithSkipExisting(opts.SkipExisting),
+		restorer.WithReChunk(opts.ReChunk),
+		restorer.WithQuickChangeCheck(opts.QuickChangeCheck),
+	)
 
 	totalErrors := 0
 	res.Error = func(location string, err error) error {

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -74,8 +74,11 @@ type RestoreOptions struct {
 	InsensitiveInclude []string
 	Target             string
 	restic.SnapshotFilter
-	Sparse bool
-	Verify bool
+	Sparse           bool
+	Verify           bool
+	SkipExisting     bool
+	ReChunk          bool
+	QuickChangeCheck bool
 }
 
 var restoreOptions RestoreOptions
@@ -93,6 +96,9 @@ func init() {
 	initSingleSnapshotFilter(flags, &restoreOptions.SnapshotFilter)
 	flags.BoolVar(&restoreOptions.Sparse, "sparse", false, "restore files as sparse")
 	flags.BoolVar(&restoreOptions.Verify, "verify", false, "verify restored files content")
+	flags.BoolVar(&restoreOptions.SkipExisting, "skip-existing", false, "skip restoring file blobs that exist on disk")
+	flags.BoolVar(&restoreOptions.ReChunk, "rechunk", false, "divide files on disk into chunks and compare these chunks with corresponding chunks from the same file in the snapshot. If this flag is not set, the chunk sizes from the snapshot files will be used to divide the files on disk for comparison. It should be used together with --skip-existing")
+	flags.BoolVar(&restoreOptions.QuickChangeCheck, "quick-change-check", false, "check if file has changed by comparing size and mtime, it should be used together with --skip-existing")
 }
 
 func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
@@ -193,7 +199,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	}
 
 	progress := restoreui.NewProgress(printer, calculateProgressInterval(!gopts.Quiet, gopts.JSON))
-	res := restorer.NewRestorer(repo, sn, opts.Sparse, progress)
+	res := restorer.NewRestorer(repo, sn, opts.Sparse, opts.SkipExisting, opts.ReChunk, opts.QuickChangeCheck, progress)
 
 	totalErrors := 0
 	res.Error = func(location string, err error) error {

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -30,7 +29,7 @@ const (
 // information about existing file
 type existingFileInfo struct {
 	location string
-	modTime  time.Time
+	info     os.FileInfo
 }
 
 // information about regular file being restored

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -69,7 +69,6 @@ type fileRestorer struct {
 
 	dst           string
 	files         []*fileInfo
-	newFiles      []*fileInfo
 	staleFiles    []*fileInfo
 	modifiedFiles []*fileInfo
 	Error         func(string, error) error
@@ -105,7 +104,7 @@ func (r *fileRestorer) addStaleFilesFile(location string) {
 }
 
 func (r *fileRestorer) addNewFile(location string, content restic.IDs, size int64) {
-	r.newFiles = append(r.newFiles, &fileInfo{location: location, blobs: content, size: size})
+	r.files = append(r.files, &fileInfo{location: location, blobs: content, size: size})
 }
 
 func (r *fileRestorer) addModifiedFilesFile(location string, content restic.IDs, size, currentSize int64, existingBlobs map[int64]struct{}) {
@@ -158,7 +157,7 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 	var packOrder restic.IDs
 
 	// create packInfo from fileInfo
-	for _, file := range append(r.newFiles, r.modifiedFiles...) {
+	for _, file := range append(r.files, r.modifiedFiles...) {
 		fileBlobs := file.blobs.(restic.IDs)
 		largeFile := len(fileBlobs) > largeFileBlobCount
 		var packsMap map[restic.ID][]fileBlobInfo

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -158,7 +158,7 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 	var packOrder restic.IDs
 
 	// create packInfo from fileInfo
-	for _, file := range r.newFiles {
+	for _, file := range append(r.newFiles, r.modifiedFiles...) {
 		fileBlobs := file.blobs.(restic.IDs)
 		largeFile := len(fileBlobs) > largeFileBlobCount
 		var packsMap map[restic.ID][]fileBlobInfo

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -320,7 +320,7 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 						file.inProgress = true
 						createSize = file.size
 					}
-					writeErr := r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize, file.sparse)
+					writeErr := r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize, file.sparse, len(file.existingBlobs) > 0)
 
 					if r.progress != nil {
 						r.progress.AddProgress(file.location, uint64(len(blobData)), uint64(file.size))

--- a/internal/restorer/fileswriter.go
+++ b/internal/restorer/fileswriter.go
@@ -53,7 +53,7 @@ func (w *filesWriter) writeToFile(path string, blob []byte, offset int64, create
 
 		var flags int
 		if createSize >= 0 {
-			flags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+			flags = os.O_CREATE | os.O_WRONLY
 		} else {
 			flags = os.O_WRONLY
 		}

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -14,16 +14,16 @@ func TestFilesWriterBasic(t *testing.T) {
 	f1 := dir + "/f1"
 	f2 := dir + "/f2"
 
-	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, 2, false))
+	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, 2, 0, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
-	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, 2, false))
+	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, 2, 0, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
-	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, -1, false))
+	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, -1, 0, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
-	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1, false))
+	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1, 0, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
 	buf, err := os.ReadFile(f1)

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -335,7 +335,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 					fmt.Printf("DEBUG: Adding modified file with existing blobs %v, location: %s, target: %s\n", existingBlobs, location, target)
 					filerestorer.addModifiedFilesFile(location, node.Content, int64(node.Size), currentSize, existingBlobs)
 				} else {
-					fmt.Printf("DEBUG: Found unchanged file, skip restoring, location: %s, target: %s\n", location, target)
+					fmt.Printf("DEBUG: Found unchanged file after compare, skip restoring, location: %s, target: %s\n", location, target)
 				}
 			} else {
 				fmt.Printf("DEBUG: Found unchanged file, skip restoring, location: %s, target: %s\n", location, target)


### PR DESCRIPTION
增量恢复第一版：

1. 支持删除 stale 文件
2. 支持跳过未修改的文件
3. 支持部分覆盖修改过的文件，只覆盖修改过的部分，跳过未修改的部分

改动：

1. 增加参数 --skip-existing （同环境变量 RESTIC_SKIP_EXISTING），用来启用增量恢复
2. 增加参数 --quick-change-check （同环境变量 RESTIC_QUICK_CHANGE_CHECK），通过检查大小和修改时间来决定这个文件是否未修改
3. 增加参数 --rechunk （同环境变量 RESTIC_RECHUNK），用 rechunk 的方式比较文件，如果未指定的话，默认采用 hash 方式

rechunk  方式是指用 CDC 算法重新切割文件，然后把每个 chunk 的哈希值和 snapshot 中的做比较。hash 方式是指直接用 snapshot 中的 chunk size 来切割文件，计算哈希值

hash 方式适用情况：
1. 本地文件和snapshot大小一样，只有中间部分字节有变动（只有更改，没有增减）
5. 本地文件比 snapshot 小，只有中间部分字节或最后一个 blob 有变动（除了最后一个 blob 可以做任意更改，其他地方只有更改，没有增减）
6. 本地文件比 snapshot 大，只有中间部分字节或最后一个 blob 有变动以及剩下的内容有变动（除了最后一个 blob 以及剩下的内容可以做任意更改，其他地方只有更改，没有增减）

rechunk 方式适用情况：
适用所有情况，但速度比 hash 慢


文件改动所有可能的情况：
1. 字节替换
2. 尾部插入字节
3. 尾部删除字节
4. 插入字节
5. 中间删除字节
6. 数据块位置变化
7. 以上所有情况的任意组合
8. 重命名

可以归纳为两种情况：offset 是否变了